### PR TITLE
랭킹 갱신 스케줄링, 캐시 TTL 설정, 메시지 처리 로직 리팩토링

### DIFF
--- a/src/main/java/pyo/quizgame/controller/FrontUserController.java
+++ b/src/main/java/pyo/quizgame/controller/FrontUserController.java
@@ -2,6 +2,7 @@ package pyo.quizgame.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -75,6 +76,7 @@ public class FrontUserController {
     }
 
     @Operation(summary = "10분마다 랭킹 갱신")
+    @Scheduled(cron = "0 */10 * * * *")
     @GetMapping("/quiz/update-user-rank")
     @ResponseBody
     public String updateUserRank() {

--- a/src/main/java/pyo/quizgame/infra/rabbitmq/QuizResultConsumer.java
+++ b/src/main/java/pyo/quizgame/infra/rabbitmq/QuizResultConsumer.java
@@ -1,10 +1,12 @@
 package pyo.quizgame.infra.rabbitmq;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Component;
 import pyo.quizgame.service.FrontUserService;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class QuizResultConsumer {
@@ -14,6 +16,12 @@ public class QuizResultConsumer {
 
     @RabbitListener(queues = "quiz.result.queue")
     public void consumeQuizResult(QuizResultMessage msg) {
-        frontUserService.applyQuizResult(msg);
+        try {
+            frontUserService.updateUserAsync(msg);
+        } catch (Exception e) {
+            log.error("유저 퀴즈 결과 반영 실패: {}", msg, e);
+            throw e; // Spring이 감지 → NACK → 재시도 or DLQ
+        }
     }
+
 }

--- a/src/main/java/pyo/quizgame/service/FrontUserService.java
+++ b/src/main/java/pyo/quizgame/service/FrontUserService.java
@@ -45,6 +45,17 @@ public class FrontUserService {
         updatePercentage(frontUserInfo.getNickName());
         return true;
     }
+    @Transactional
+    public void updateUserAsync(QuizResultMessage msg) {
+        frontUserRepository.incrementQuizCount(
+                msg.getNickName(),
+                msg.getTotalQuizCount(),
+                msg.getSolvedQuizCount()
+        );
+        updatePercentage(msg.getNickName());
+
+    }
+
 
     @Transactional
     public void updatePercentage(String nickName) {
@@ -93,21 +104,8 @@ public class FrontUserService {
         return "OK";
     }
 
-    @Transactional
-    public void applyQuizResult(QuizResultMessage msg) {
-        frontUserRepository.incrementQuizCount(
-                msg.getNickName(),
-                msg.getTotalQuizCount(),
-                msg.getSolvedQuizCount()
-        );
 
-        UserStats stats = frontUserRepository.fetchStats(msg.getNickName());
 
-        frontUserRepository.updatePercentage(
-                msg.getNickName(),
-                String.format("%.2f", stats.getSolvedQuizCount() * 100.0 / stats.getTotalQuizCount())
-        );
-    }
 
 
     @Transactional(readOnly = true)

--- a/src/main/java/pyo/quizgame/service/RankService.java
+++ b/src/main/java/pyo/quizgame/service/RankService.java
@@ -11,6 +11,7 @@ import pyo.quizgame.domain.FrontUserInfo;
 import pyo.quizgame.domain.UserRankInfo;
 import pyo.quizgame.repository.RankRepository;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -67,6 +68,7 @@ public class RankService {
         }
 
         saveAll(userRankInfos);
+        redisTemplate.expire(REDIS_RANK_KEY, Duration.ofMinutes(15));
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
### 작업 개요
- 랭킹 갱신을 자동화하고, 캐시의 데이터 정합성을 유지하며, 메시지 처리 안정성을 강화

### 주요 변경 사항
1. `@Scheduled`를 활용하여 랭킹 갱신을 10분마다 자동 실행되도록 구현
2. 메시지 처리 로직을 `updateUserAsync()`로 분리하고 예외 발생 시 NACK 처리되도록 `try-catch` 적용
3. Redis에 저장되는 랭킹 캐시에 TTL(15분) 설정하여 오래된 데이터 자동 삭제 처리

### 기대 효과
- 랭킹 갱신을 수동으로 호출하지 않아도 되므로 운영 편의성 향상
- 메시지 처리 실패 시 DLQ 등으로 연계 가능한 구조 확립
- 데이터가 stale 상태로 오래 유지되지 않도록 TTL을 통해 정합성 확보
